### PR TITLE
Fix bugs related to selecting 0 secondary datasets

### DIFF
--- a/app/colocalization/stages/collect_user_input.py
+++ b/app/colocalization/stages/collect_user_input.py
@@ -53,8 +53,9 @@ class CollectUserInputStage(PipelineStage):
         payload.simple_sum_locus = payload.request_form.get("SSlocus", "")
 
         # GTEx
-        payload.gtex_tissues = payload.request_form.get("GTEx-tissues")  # type: ignore
-        payload.gtex_genes = payload.request_form.get("region-genes")  # type: ignore
+        payload.gtex_tissues = payload.request_form.get("GTEx-tissues", [])  # type: ignore
+        payload.gtex_genes = payload.request_form.get("region-genes", [])  # type: ignore
+
         if len(payload.gtex_tissues) > 0 and len(payload.gtex_genes) == 0:
             errors.append(
                 "Please select one or more genes to complement your GTEx tissue(s) selection"

--- a/app/colocalization/stages/coloc_simple_sum.py
+++ b/app/colocalization/stages/coloc_simple_sum.py
@@ -66,6 +66,10 @@ class ColocSimpleSumStage(PipelineStage):
 
         p_value_matrix, coloc2eqtl_df = self._build_pvalue_matrix(payload)
 
+        if len(p_value_matrix) == 1:
+            # Only GWAS data was provided, no secondary datasets
+            raise InvalidUsage("No secondary datasets provided for colocalization. Please select at least one GTEx tissue/gene combination, or upload a secondary dataset.\nIf you would like to run a set-based test for your GWAS data, please use the Set-Based Test form in the navbar instead.")
+
         self._run_simple_sum(
             p_value_matrix, payload, coloc2eqtl_df,
         )

--- a/app/routes.py
+++ b/app/routes.py
@@ -1835,7 +1835,7 @@ def prev_session():
         old_session_id = request.form["session-id"].strip()
 
         # Check celery session
-        if not app.config["DISABLE_CELERY"] and get_is_celery_running():
+        if not app.config["DISABLE_CELERY"] and get_is_celery_running() and old_session_id != "example-output":
             celery_result = AsyncResult(old_session_id, app=app.extensions["celery"])
             if celery_result.status == "PENDING":
                 raise InvalidUsage(f"Session {old_session_id} does not exist.")
@@ -1894,7 +1894,7 @@ def prev_session():
 def prev_session_input(old_session_id):
 
     # Check celery session
-    if not app.config["DISABLE_CELERY"] and get_is_celery_running():
+    if not app.config["DISABLE_CELERY"] and get_is_celery_running() and old_session_id != "example-output":
         celery_result = AsyncResult(old_session_id, app=app.extensions["celery"])
         if celery_result.status == "PENDING":
             raise InvalidUsage(f"Session {old_session_id} does not exist.")


### PR DESCRIPTION
- Fixes default values for getting selected GTEx tissues/genes
- Adds check for if the user provides/selects _any_ secondary datasets before colocalization (they must provide at least 1 secondary dataset for coloc to work)
- Add edge case for getting the example-output session