### PR TITLE
Fixes for initial docker implementation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -98,8 +98,5 @@ COPY --chown=$USERNAME:$USERNAME ./pyproject.toml /code/pyproject.toml
 COPY --chown=$USERNAME:$USERNAME ./poetry.lock /code/poetry.lock
 COPY --chown=$USERNAME:$USERNAME ./README.md /code/README.md
 COPY --chown=$USERNAME:$USERNAME ./app /code/app
-COPY --chown=$USERNAME:$USERNAME ./tests /code/app
-COPY --chown=$USERNAME:$USERNAME ./data /code/app
-COPY --chown=$USERNAME:$USERNAME ./misc /code/app
 
 RUN poetry install --with dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,6 +88,9 @@ RUN install2.r --error \
 RUN R -e "BiocManager::install('GenomicRanges')"
 RUN R -e "BiocManager::install('biomaRt')"
 
+# Link plink to work dir
+RUN ln -s /usr/local/bin/plink /code/plink
+
 # this seems not to respect user install path, might need to install as root and copy over
 # RUN R -e "remotes::install_version('Matrix', version = '1.2')" # this seems to be already installed via other deps, however
 

--- a/app/config.py
+++ b/app/config.py
@@ -52,9 +52,9 @@ class BaseConfig:
         ],
     }
 
-    APP_ENV = os.environ["APP_ENV"]
+    APP_ENV = os.environ.get("APP_ENV", "production")
 
-    FLASK_APP_DEBUG = os.environ["FLASK_APP_DEBUG"]
+    FLASK_APP_DEBUG = os.environ.get("FLASK_APP_DEBUG", "False").lower() == "true"
 
     UPLOAD_FOLDER = os.path.abspath(
         os.path.join(os.path.dirname(__file__), "static", "upload")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,6 @@ services:
       - ./app:/code/app
       - ./misc:/code/misc
       - ./data:/code/data
-      - ${DATA_DIR}:/code/data
       - ./tests:/code/tests
       - ./pyproject.toml:/code/pyproject.toml
       - ./poetry.lock:/code/poetry.lock
@@ -23,6 +22,7 @@ services:
       - FLASK_DEBUG=1
       - FLASK_SECRET_KEY
       - MONGO_CONNECTION_STRING
+      - DISABLE_CELERY=true
     entrypoint: ["python3", "-m", "app.wsgi"]
   mongo:
     image:  mongo:6


### PR DESCRIPTION
Adjusts some parameters for the initial docker implementation so that the project can still be run locally.
- Fix PLINK path handling; add symlink in docker container for plink as fallback path
- Disable Celery in docker compose file (for now)
- Safe defaults for configs