### PR TITLE
Add format check for SNP column

### DIFF
--- a/app/colocalization/stages/read_gwas_file.py
+++ b/app/colocalization/stages/read_gwas_file.py
@@ -22,7 +22,8 @@ class GWASColumn:
     coloc2: bool = False  # Required for coloc2?
     optional: bool = False  # Optional column
 
-
+#                                                              (bi-allelic variants are allowed)
+#                      (prefix) chrom        pos      ref       alt(s)                build
 VCF_FORMAT_PATTERN = "^(?:chr)?([0-9]{1,2})_([0-9]+)_([ATCG]+)_([ATCG]+(?:,[ATCG]+)*)_b3(?:7|8)$"
 
 

--- a/app/colocalization/stages/read_gwas_file.py
+++ b/app/colocalization/stages/read_gwas_file.py
@@ -388,6 +388,6 @@ class ReadGWASFileStage(PipelineStage):
             if len(vcf_snps) != len(merged_vcf_snps):
                 raise InvalidUsage(
                     "GWAS data contains SNPs with chrom_pos_ref_alt_build format that are not consistent (eg. reversed alleles, incorrect position or chromosome). "
-                    "Please inspect your GWAS file and ensure that the SNP column is consistent with the values in other columns in the GWAS file."
-                    f"'{len(vcf_snps) - len(merged_vcf_snps)}' of '{len(gwas_data)}' SNPs are inconsistent."
+                    "Please inspect your GWAS file and ensure that the SNP column is consistent with the values in other columns in the GWAS file. "
+                    f"{len(vcf_snps) - len(merged_vcf_snps)} of {len(gwas_data)} SNPs are inconsistent."
                 )

--- a/app/colocalization/stages/read_gwas_file.py
+++ b/app/colocalization/stages/read_gwas_file.py
@@ -314,7 +314,7 @@ class ReadGWASFileStage(PipelineStage):
         )
         if not all(gwas_indices_kept):
             app.logger.debug(
-                f"Some SNPs were removed from GWAS dataset during format check: {[i for i, x in enumerate(list(gwas_indices_kept)) if not x]}"
+                f"{sum(gwas_indices_kept)} SNPs kept, {sum(~gwas_indices_kept)} SNPs removed."
             )
         gwas_data = gwas_data.loc[gwas_indices_kept].copy()
         gwas_data.sort_values(by=["POS"], inplace=True)

--- a/app/colocalization/stages/read_gwas_file.py
+++ b/app/colocalization/stages/read_gwas_file.py
@@ -23,7 +23,7 @@ class GWASColumn:
     optional: bool = False  # Optional column
 
 
-VCF_FORMAT_PATTERN = "^(?:chr)?([0-9]{1,2})_([0-9]+)_([ATCG]+)_([ATCG]+)_b3(?:7|8)$"
+VCF_FORMAT_PATTERN = "^(?:chr)?([0-9]{1,2})_([0-9]+)_([ATCG]+)_([ATCG]+(?:,[ATCG]+)*)_b3(?:7|8)$"
 
 
 class ReadGWASFileStage(PipelineStage):

--- a/app/templates/components/form/snp-col.html
+++ b/app/templates/components/form/snp-col.html
@@ -4,7 +4,7 @@
   data-toggle="tooltip"
   title=""
   class="font-weight-bold"
-  data-original-title="<p>Header text corresponding to the variant name column in your txt/tsv file (primary dataset).</p><p>Accepted formats: rs7512462, 1_205899595_T_C_b37.</p>"
+  data-original-title="<p>Header text corresponding to the variant name column in your txt/tsv file (primary dataset).</p><p>Accepted formats: rsID (eg. rs7512462), chrom_pos_ref_alt_build format (eg. 1_205899595_T_C_b37).</p>"
 >
   Marker Column Name:
 </label>
@@ -18,5 +18,5 @@
   data-toggle="tooltip"
   data-html="true"
   title=""
-  data-original-title="<p>Enter the header text corresponding to the variant ID column in your txt/tsv file (primary dataset).</p><p>Accepted formats: rs7512462, 1_205899595_T_C_b37</p>"
+  data-original-title="<p>Enter the header text corresponding to the variant name column in your txt/tsv file (primary dataset).</p><p>Accepted formats: rsID (eg. rs7512462), chrom_pos_ref_alt_build format (eg. 1_205899595_T_C_b37).</p>"
 />


### PR DESCRIPTION
A rare bug happens when a user uploads a GWAS file with a SNP column with `chrom_pos_ref_alt_build` format, where ref and alt are switched. This PR adds a format check for this case, as well as checking other inconsistencies 